### PR TITLE
Use vue-typecast

### DIFF
--- a/src/routes/tools/BaseConverter.vue
+++ b/src/routes/tools/BaseConverter.vue
@@ -8,7 +8,7 @@
                             label="Input base"
                             outlined
                             type="number"
-                            v-model="inputBase"
+                            v-model.number="inputBase"
                             ref="inputBase"
                             hide-details="auto"
                             :rules="baseRules"
@@ -33,7 +33,7 @@
                             label="Output base"
                             outlined
                             type="number"
-                            v-model="outputBase"
+                            v-model.number="outputBase"
                             ref="outputBase"
                             :rules="baseRules"
                     />

--- a/src/routes/tools/UuidGenerator.vue
+++ b/src/routes/tools/UuidGenerator.vue
@@ -5,7 +5,7 @@
         <v-card-text>
             <v-text-field
                     outlined
-                    v-model="quantity"
+                    v-model.number="quantity"
                     ref="quantity"
                     type="number"
                     label="Quantity"

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -25,7 +25,7 @@ const formatBytes = (bytes, decimals = 2) => {
 }
 
 const isInt = (value) => {
-    return Number.isInteger(parseFloat(value));
+    return Number.isInteger(value);
 }
 
 export {


### PR DESCRIPTION
`isInt` shouldn't be able to return true when entering a string.
Luckily Vue can automatically cast the input of a textfield to a number, so you don't have to worry about that at all.

Documented here:
https://vuejs.org/v2/guide/forms.html#number