### PR TITLE
Compute all hashes at the same time instead of using a select

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+    "printWidth": 130,
+    "singleQuote": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,0 @@
-{
-    "printWidth": 130,
-    "singleQuote": true
-}

--- a/src/tools/hash-text/hash-text.vue
+++ b/src/tools/hash-text/hash-text.vue
@@ -35,7 +35,7 @@ type AlgoNames = keyof typeof algos;
 const algoNames = Object.keys(algos) as AlgoNames[];
 
 const clearText = ref(
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacus metus blandit dolor lacus natoque ad fusce aliquam velit.'
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacus metus blandit dolor lacus natoque ad fusce aliquam velit.',
 );
-const hashText = (algo: AlgoNames, value: string) => (value ? algos[algo](value).toString() : '');
+const hashText = (algo: AlgoNames, value: string) => algos[algo](value).toString();
 </script>

--- a/src/tools/hash-text/hash-text.vue
+++ b/src/tools/hash-text/hash-text.vue
@@ -5,10 +5,10 @@
 
       <n-divider />
 
-      <div v-for="algo in list" :key="algo" style="margin: 5px 0">
+      <div v-for="algo in algoNames" :key="algo" style="margin: 5px 0">
         <n-input-group>
           <n-input-group-label style="flex: 0 0 120px"> {{ algo }} </n-input-group-label>
-          <input-copyable :value="hashedText(algo, clearText)" readonly />
+          <input-copyable :value="hashText(algo, clearText)" readonly />
         </n-input-group>
       </div>
     </n-card>
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 import InputCopyable from '../../components/InputCopyable.vue';
-import { ref, computed } from 'vue';
+import { ref } from 'vue';
 import { MD5, SHA1, SHA256, SHA224, SHA512, SHA384, SHA3, RIPEMD160 } from 'crypto-js';
 
 const algos = {
@@ -31,11 +31,11 @@ const algos = {
   RIPEMD160,
 } as const;
 
-type Algo = keyof typeof algos;
-const list = Object.keys(algos) as Algo[];
+type AlgoNames = keyof typeof algos;
+const algoNames = Object.keys(algos) as AlgoNames[];
 
 const clearText = ref(
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacus metus blandit dolor lacus natoque ad fusce aliquam velit.'
 );
-const hashedText = (algo: Algo, value: string) => (value ? algos[algo](value).toString() : '');
+const hashText = (algo: AlgoNames, value: string) => (value ? algos[algo](value).toString() : '');
 </script>

--- a/src/tools/hash-text/hash-text.vue
+++ b/src/tools/hash-text/hash-text.vue
@@ -2,34 +2,21 @@
   <div>
     <n-card>
       <n-input v-model:value="clearText" type="textarea" placeholder="Your string..." :autosize="{ minRows: 3 }" />
-      <br />
-      <br />
-      <n-select v-model:value="algo" :options="Object.keys(algos).map((label) => ({ label, value: label }))" />
 
-      <br />
-      <n-input
-        style="text-align: center"
-        :value="hashedText"
-        type="textarea"
-        placeholder="Your string hash"
-        :autosize="{ minRows: 1 }"
-        readonly
-        autocomplete="off"
-        autocorrect="off"
-        autocapitalize="off"
-        spellcheck="false"
-      />
-      <br />
-      <br />
-      <n-space justify="center">
-        <n-button secondary autofocus @click="copy"> Copy </n-button>
-      </n-space>
+      <n-divider />
+
+      <div v-for="algo in list" :key="algo" style="margin: 5px 0">
+        <n-input-group>
+          <n-input-group-label style="flex: 0 0 120px"> {{ algo }} </n-input-group-label>
+          <input-copyable :value="hashedText(algo, clearText)" readonly />
+        </n-input-group>
+      </div>
     </n-card>
   </div>
 </template>
 
 <script setup lang="ts">
-import { useCopy } from '@/composable/copy';
+import InputCopyable from '../../components/InputCopyable.vue';
 import { ref, computed } from 'vue';
 import { MD5, SHA1, SHA256, SHA224, SHA512, SHA384, SHA3, RIPEMD160 } from 'crypto-js';
 
@@ -44,11 +31,11 @@ const algos = {
   RIPEMD160,
 } as const;
 
-const clearText = ref(
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacus metus blandit dolor lacus natoque ad fusce aliquam velit.',
-);
-const algo = ref<keyof typeof algos>('SHA256');
-const hashedText = computed(() => algos[algo.value](clearText.value).toString());
+type Algo = keyof typeof algos;
+const list = Object.keys(algos) as Algo[];
 
-const { copy } = useCopy({ source: hashedText, text: 'Hash copied to the clipboard' });
+const clearText = ref(
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacus metus blandit dolor lacus natoque ad fusce aliquam velit.'
+);
+const hashedText = (algo: Algo, value: string) => (value ? algos[algo](value).toString() : '');
 </script>


### PR DESCRIPTION
Instead of showing a select dropdown - compute all hashes at the same time and have a copy-able input.

(I've also added a very basic prettier config, which tries to make the least amount of changes when re-formatting)