### PR TITLE
fix: update recommended extension ids

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
 }


### PR DESCRIPTION
The recommended extensions have changed ownership and now VS Code shows a notification that the ones listed in the json file are not found in the marketplace.

<img width="463" alt="Screen Shot 2022-05-10 at 11 07 32 am" src="https://user-images.githubusercontent.com/524259/167831739-90e1203b-420a-462c-ae96-c8a010131ad1.png">

[Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)

[TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)