### PR TITLE
Device information page styling fix

### DIFF
--- a/src/tools/device-information/device-information.vue
+++ b/src/tools/device-information/device-information.vue
@@ -89,7 +89,6 @@ const sections = [
   .value {
     font-size: 20px;
     font-weight: 400;
-    margin-top: -5px;
   }
 }
 </style>

--- a/src/tools/device-information/device-information.vue
+++ b/src/tools/device-information/device-information.vue
@@ -89,7 +89,7 @@ const sections = [
   .value {
     font-size: 20px;
     font-weight: 400;
-    line-height: 1;
+    margin-top: -5px;
   }
 }
 </style>


### PR DESCRIPTION
I was checking out your site, and really like it! already added to my bookmarks, and when I was on the Device Information page I noticed the `p` and `y` in the words 1 dppx and landscape-primary were cut off and my ocd kicked in to tweak it.
The fix was to remove the line height set on the value, and then to keep the spacing how it was just moving it up 5px seemed to do the trick.

I'm using Firefox 102.0.1 on Windows 11. I'll attach some pics so you can see the before and after.

I've never messed with vue, but after looking at this file here ya make me want to check it out more. I love how its keeping it all together in one file.
Might also need to rebuild it the site after this change, but you get the point. 

Awesome site!
Before:
![it-tools-b4](https://user-images.githubusercontent.com/2002591/181593874-a2c0471d-fb2d-418d-8392-61998908b469.jpg)

After
![it-tools-after](https://user-images.githubusercontent.com/2002591/181593897-251222e3-d3ed-419e-958f-ac00c9ee3f39.jpg)
