### PR TITLE
fix(ipv4-range-expander): calculate correct for ip addresses where the first octet is lower than 128

### DIFF
--- a/src/tools/ipv4-range-expander/ipv4-range-expander.e2e.spec.ts
+++ b/src/tools/ipv4-range-expander/ipv4-range-expander.e2e.spec.ts
@@ -23,6 +23,20 @@ test.describe('Tool - IPv4 range expander', () => {
     expect(await page.getByTestId('cidr.new').textContent()).toEqual('192.168.0.0/21');
   });
 
+  test('Calculates correct for valid input, where first octet is lower than 128', async ({ page }) => {
+    await page.getByPlaceholder('Start IPv4 address...').fill('10.0.0.1');
+    await page.getByPlaceholder('End IPv4 address...').fill('10.0.0.17');
+
+    expect(await page.getByTestId('start-address.old').textContent()).toEqual('10.0.0.1');
+    expect(await page.getByTestId('start-address.new').textContent()).toEqual('10.0.0.0');
+    expect(await page.getByTestId('end-address.old').textContent()).toEqual('10.0.0.17');
+    expect(await page.getByTestId('end-address.new').textContent()).toEqual('10.0.0.31');
+    expect(await page.getByTestId('addresses-in-range.old').textContent()).toEqual('17');
+    expect(await page.getByTestId('addresses-in-range.new').textContent()).toEqual('32');
+    expect(await page.getByTestId('cidr.old').textContent()).toEqual('');
+    expect(await page.getByTestId('cidr.new').textContent()).toEqual('10.0.0.0/27');
+  });
+
   test('Hides result for invalid input', async ({ page }) => {
     await page.getByPlaceholder('Start IPv4 address...').fill('192.168.1.1');
     await page.getByPlaceholder('End IPv4 address...').fill('192.168.0.255');

--- a/src/tools/ipv4-range-expander/ipv4-range-expander.service.test.ts
+++ b/src/tools/ipv4-range-expander/ipv4-range-expander.service.test.ts
@@ -14,6 +14,17 @@ describe('ipv4RangeExpander', () => {
       expect(result?.newCidr).toEqual('192.168.0.0/21');
     });
 
+    it('should calculate valid cidr for given addresses, where first octet is lower than 128', () => {
+      const result = calculateCidr({ startIp: '10.0.0.1', endIp: '10.0.0.17' });
+
+      expect(result).toBeDefined();
+      expect(result?.oldSize).toEqual(17);
+      expect(result?.newSize).toEqual(32);
+      expect(result?.newStart).toEqual('10.0.0.0');
+      expect(result?.newEnd).toEqual('10.0.0.31');
+      expect(result?.newCidr).toEqual('10.0.0.0/27');
+    });
+
     it('should return empty result for invalid input', () => {
       expect(calculateCidr({ startIp: '192.168.7.1', endIp: '192.168.6.255' })).not.toBeDefined();
     });

--- a/src/tools/ipv4-range-expander/ipv4-range-expander.service.ts
+++ b/src/tools/ipv4-range-expander/ipv4-range-expander.service.ts
@@ -40,12 +40,12 @@ function calculateCidr({ startIp, endIp }: { startIp: string; endIp: string }) {
     value: ipv4ToInt({ ip: startIp }).toString(),
     fromBase: 10,
     toBase: 2,
-  });
+  }).padStart(32, '0');
   const end = convertBase({
     value: ipv4ToInt({ ip: endIp }).toString(),
     fromBase: 10,
     toBase: 2,
-  });
+  }).padStart(32, '0');
 
   const cidr = getCidr(start, end);
   if (cidr != null) {


### PR DESCRIPTION
Fixes #399 