### PR TITLE
cd: parametrize listen port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ RUN pnpm build
 FROM nginx:stable-alpine AS production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+COPY startup.sh /docker-entrypoint.d/startup.sh
+ENV PORT 80
+EXPOSE ${PORT}
 CMD ["nginx", "-g", "daemon off;"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Generate the nginx.conf with PORT env or default to 80
+cat > /etc/nginx/conf.d/default.conf <<EOF
+server {
+    listen ${PORT:-80};
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+EOF


### PR DESCRIPTION
This pull request introduces enables the parametrization of the Nginx listen port using an environment variable. The motivation behind this change is to optimize the container for usage within a Docker Compose setup, where individual services' ports are not directly mapped to host ports. Instead, the container port is accessed via a reverse proxy container on the same Docker network. The objective is to provide the flexibility to avoid port collisions with other services that are also bound to port 80 and cannot be modified.

**Benefits:**

- Docker Compose compatibility: By enabling the parametrization of the Nginx listen port, this change streamlines the deployment of the "it-tools" container within a Docker Compose setup. Users can leverage the container port for internal communication and access it via a reverse proxy, eliminating the need for manual host port mapping.

- Avoids port collisions: This modification offers users the ability to assign a different port to the "it-tools" container, mitigating conflicts with other services that are bound to port 80 and cannot be reconfigured. The flexibility to select a unique port enhances the stability and coexistence of services within the Docker network.