### PR TITLE
Netlify deployment support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+TZ='Asia/Ho_Chi_Minh'
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,3 @@
-TZ='Asia/Ho_Chi_Minh'
-
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
When deploying to Netlify without this config file, you will encounter 404 problems when reloading the page.