### PR TITLE
Added symbolic representation to chmod-calculator

### DIFF
--- a/src/tools/chmod-calculator/chmod-calculator.service.test.ts
+++ b/src/tools/chmod-calculator/chmod-calculator.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeChmodOctalRepresentation } from './chmod-calculator.service';
+import { computeChmodOctalRepresentation, computeChmodSymbolicRepresentation } from './chmod-calculator.service';
 
 describe('chmod-calculator', () => {
   describe('computeChmodOctalRepresentation', () => {
@@ -63,6 +63,68 @@ describe('chmod-calculator', () => {
           },
         }),
       ).to.eql('222');
+    });
+
+    it('get the symbolic representation from permissions', () => {
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: true, write: true, execute: true },
+            group: { read: true, write: true, execute: true },
+            public: { read: true, write: true, execute: true },
+          },
+        }),
+      ).to.eql('rwxrwxrwx');
+
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: false, write: false, execute: false },
+            group: { read: false, write: false, execute: false },
+            public: { read: false, write: false, execute: false },
+          },
+        }),
+      ).to.eql('---------');
+
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: false, write: true, execute: false },
+            group: { read: false, write: true, execute: true },
+            public: { read: true, write: false, execute: true },
+          },
+        }),
+      ).to.eql('-w--wxr-x');
+
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: true, write: false, execute: false },
+            group: { read: false, write: true, execute: false },
+            public: { read: false, write: false, execute: true },
+          },
+        }),
+      ).to.eql('r---w---x');
+
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: false, write: false, execute: true },
+            group: { read: false, write: true, execute: false },
+            public: { read: true, write: false, execute: false },
+          },
+        }),
+      ).to.eql('--x-w-r--');
+
+      expect(
+        computeChmodSymbolicRepresentation({
+          permissions: {
+            owner: { read: false, write: true, execute: false },
+            group: { read: false, write: true, execute: false },
+            public: { read: false, write: true, execute: false },
+          },
+        }),
+      ).to.eql('-w--w--w-');
     });
   });
 });

--- a/src/tools/chmod-calculator/chmod-calculator.service.ts
+++ b/src/tools/chmod-calculator/chmod-calculator.service.ts
@@ -1,13 +1,26 @@
 import _ from 'lodash';
 import type { GroupPermissions, Permissions } from './chmod-calculator.types';
 
-export { computeChmodOctalRepresentation };
+export { computeChmodOctalRepresentation, computeChmodSymbolicRepresentation };
 
 function computeChmodOctalRepresentation({ permissions }: { permissions: Permissions }): string {
   const permissionValue = { read: 4, write: 2, execute: 1 };
 
   const getGroupPermissionValue = (permission: GroupPermissions) =>
     _.reduce(permission, (acc, isPermSet, key) => acc + (isPermSet ? _.get(permissionValue, key, 0) : 0), 0);
+
+  return [
+    getGroupPermissionValue(permissions.owner),
+    getGroupPermissionValue(permissions.group),
+    getGroupPermissionValue(permissions.public),
+  ].join('');
+}
+
+function computeChmodSymbolicRepresentation({ permissions }: { permissions: Permissions }): string {
+  const permissionValue = { read: 'r', write: 'w', execute: 'x' };
+
+  const getGroupPermissionValue = (permission: GroupPermissions) =>
+    _.reduce(permission, (acc, isPermSet, key) => acc + (isPermSet ? _.get(permissionValue, key, '') : '-'), '');
 
   return [
     getGroupPermissionValue(permissions.owner),

--- a/src/tools/chmod-calculator/chmod-calculator.vue
+++ b/src/tools/chmod-calculator/chmod-calculator.vue
@@ -2,7 +2,7 @@
 import { useThemeVars } from 'naive-ui';
 
 import InputCopyable from '../../components/InputCopyable.vue';
-import { computeChmodOctalRepresentation } from './chmod-calculator.service';
+import { computeChmodOctalRepresentation, computeChmodSymbolicRepresentation } from './chmod-calculator.service';
 
 import type { Group, Scope } from './chmod-calculator.types';
 
@@ -22,6 +22,7 @@ const permissions = ref({
 });
 
 const octal = computed(() => computeChmodOctalRepresentation({ permissions: permissions.value }));
+const symbolic = computed(() => computeChmodSymbolicRepresentation({ permissions: permissions.value }));
 </script>
 
 <template>
@@ -56,6 +57,9 @@ const octal = computed(() => computeChmodOctalRepresentation({ permissions: perm
 
     <div class="octal-result">
       {{ octal }}
+    </div>
+    <div class="octal-result">
+      {{ symbolic }}
     </div>
 
     <InputCopyable :value="`chmod ${octal} path`" readonly />


### PR DESCRIPTION
Added the symbolic representation (rwxrwxrwx) to the chmod-calculator. Also added relevant tests.

Somewhat addresses #418. This is my first time working with vue, so was not quite up to the task of implementing the request entirely.  