### PR TITLE
Corrected example for ETA calculation.

### DIFF
--- a/src/tools/eta-calculator/eta-calculator.vue
+++ b/src/tools/eta-calculator/eta-calculator.vue
@@ -26,8 +26,8 @@ const endAt = computed(() =>
 <template>
   <div>
     <div text-justify op-70>
-      With a concrete example, if you wash 3 plates in 5 minutes and you have 500 plates to wash, it will take you 5
-      hours and 10 minutes to wash them all.
+      With a concrete example, if you wash 5 plates in 3 minutes and you have 500 plates to wash, it will take you 5
+      hours to wash them all.
     </div>
     <n-divider />
     <div flex gap-2>


### PR DESCRIPTION
The current example makes no sense/is incorrect:

`if you wash 3 plates in 5 minutes and you have 500 plates to wash, it will take you 5 hours and 10 minutes to wash them all`

500 plates / 3 plates per time unit = 166.66... time units * 5 minutes = 833.33... minutes total time. (= 13.88... hours, not 5h 10m).


New example:

`if you wash 5 plates in 3 minutes and you have 500 plates to wash, it will take you 5 hours to wash them all`

500 plates / 5 plates per time unit = 100 time units * 3 minutes = 300 minutes = 5 hours