### PR TITLE
fix(base64-file-converter): fix downloading of index.html content without data preambula

### DIFF
--- a/src/composable/downloadBase64.ts
+++ b/src/composable/downloadBase64.ts
@@ -1,15 +1,13 @@
 import { extension as getExtensionFromMime } from 'mime-types';
 import type { Ref } from 'vue';
 
-function getFileExtensionFromBase64({
-  base64String,
+function getFileExtensionFromMime({
+  hasMimeType,
   defaultExtension = 'txt',
 }: {
-  base64String: string
+  hasMimeType: string[] | null
   defaultExtension?: string
 }) {
-  const hasMimeType = base64String.match(/data:(.*?);base64/i);
-
   if (hasMimeType) {
     return getExtensionFromMime(hasMimeType[1]) || defaultExtension;
   }
@@ -20,13 +18,16 @@ function getFileExtensionFromBase64({
 export function useDownloadFileFromBase64({ source, filename }: { source: Ref<string>; filename?: string }) {
   return {
     download() {
-      const base64String = source.value;
-
-      if (base64String === '') {
+      if (source.value === '') {
         throw new Error('Base64 string is empty');
       }
 
-      const cleanFileName = filename ?? `file.${getFileExtensionFromBase64({ base64String })}`;
+      const hasMimeType = source.value.match(/data:(.*?);base64/i);
+      const base64String = hasMimeType
+        ? source.value
+        : `data:text/plain;base64,${source.value}`;
+
+      const cleanFileName = filename ?? `file.${getFileExtensionFromMime({ hasMimeType })}`;
 
       const a = document.createElement('a');
       a.href = base64String;


### PR DESCRIPTION
Hi! Thanks for great utilities site.

I have found that base64-file-converter tool doesn't work properly.
The downloaded file has content of site's `index.html` if I've paste base64 string without preifx like `data:plain/text;base64,`.

This PR fixes that behavior by adding `data:plain/text;base64,` to base64 string if `data:` not found in the input string.
Please, consider to review and merge this PR.

### Reproducing

Example of plain base64 string for testing:
```
c2VydmVyIHsNCiAgICBsaXN0ZW4gODA7DQogICAgc2VydmVyX25hbWUgbG9jYWxob3N0Ow0KICAgIHJvb3QgL3Vzci9zaGFyZS9uZ2lueC9odG1sOw0KICAgIGluZGV4IGluZGV4Lmh0bWw7DQoNCiAgICBsb2NhdGlvbiAvIHsNCiAgICAgICAgdHJ5X2ZpbGVzICR1cmkgJHVyaS8gL2luZGV4Lmh0bWw7DQogICAgfQ0KfQ==
```

With this input, in main branch, click on "Download file" button will download HTML of site. In PR branch it will download correct byte representation of base64 content.