### PR TITLE
Updated tool command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pnpm lint
 To create a new tool, there is a script that generate the boilerplate of the new tool, simply run:
 
 ```sh
-pnpm run script:create-new-tool my-tool-name
+pnpm run script:create:tool my-tool-name
 ```
 
 It will create a directory in `src/tools` with the correct files, and a the import in `src/tools/index.ts`. You will just need to add the imported tool in the proper category and develop the tool.


### PR DESCRIPTION
It seems that the command to create a new tool was updated about a month ago but wasn't reflected in the README.md file.

This pull request fixes that :)