### PR TITLE
fix: stop camera recorder

### DIFF
--- a/src/tools/camera-recorder/camera-recorder.vue
+++ b/src/tools/camera-recorder/camera-recorder.vue
@@ -84,7 +84,7 @@ watchEffect(() => {
   }
 });
 
-onBeforeUnmount(() => stop())
+onBeforeUnmount(() => stop());
 
 async function requestPermissions() {
   try {

--- a/src/tools/camera-recorder/camera-recorder.vue
+++ b/src/tools/camera-recorder/camera-recorder.vue
@@ -28,6 +28,7 @@ const permissionCannotBePrompted = ref(false);
 const {
   stream,
   start,
+  stop,
   enabled: isMediaStreamAvailable,
 } = useUserMedia({
   constraints: computed(() => ({
@@ -82,6 +83,8 @@ watchEffect(() => {
     video.value.srcObject = stream.value;
   }
 });
+
+onBeforeUnmount(() => stop())
 
 async function requestPermissions() {
   try {


### PR DESCRIPTION
Issue:

For the camera recorder, the camera will stay turned on after switching between tools/pages.
A full refresh of the page is required to stop it

Fix:

Stop the media stream when user navigates away from the camera recorder tool