### PR TITLE
fix(format-transformer): set overflow for output area width

### DIFF
--- a/src/components/FormatTransformer.vue
+++ b/src/components/FormatTransformer.vue
@@ -48,7 +48,7 @@ const output = computed(() => transformer.value(input.value));
     monospace
   />
 
-  <div>
+  <div overflow-auto>
     <div mb-5px>
       {{ outputLabel }}
     </div>


### PR DESCRIPTION
This PR fixed a style issue of component FormatTransformer, which is used in tools `json-to-toml`, `json-to-yaml` and so on.

This PR fixed issue https://github.com/CorentinTh/it-tools/issues/780