### PR TITLE
feat(i18n): added vietnamese translation

### DIFF
--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -1,0 +1,71 @@
+home:
+  categories:
+    newestTools: Công cụ mới nhất
+    favoriteTools: 'Công cụ yêu thích của bạn'
+    allTools: 'Tất cả công cụ'
+  subtitle: 'Công cụ tiện ích cho nhà phát triển'
+  toggleMenu: 'Chuyển đổi menu'
+  home: Trang chủ
+  uiLib: 'Thư viện UI'
+  support: 'Hỗ trợ phát triển IT Tools'
+  buyMeACoffee: 'Ủng hộ tác giả'
+  follow:
+    title: 'Bạn thích IT-tools?'
+    p1: 'Hãy cho chúng tôi một ngôi sao trên'
+    githubRepository: 'Kho GitHub IT-Tools'
+    p2: 'hoặc theo dõi chúng tôi trên'
+    twitterAccount: 'Tài khoản Twitter IT-Tools'
+    thankYou: 'Cảm ơn bạn!'
+  nav:
+    github: 'Kho GitHub'
+    githubRepository: 'Kho GitHub IT-Tools'
+    twitter: 'Tài khoản Twitter'
+    twitterAccount: 'Tài khoản Twitter IT Tools'
+    about: 'Về IT-Tools'
+    aboutLabel: 'Giới thiệu'
+    darkMode: 'Chế độ tối'
+    lightMode: 'Chế độ sáng'
+    mode: 'Chuyển đổi chế độ tối/sáng'
+about:
+  content: >
+    # Về IT-Tools
+
+    Website tuyệt vời này, được tạo ra bằng ❤ bởi [Corentin Thomasset](https://github.com/CorentinTh), tổng hợp các công cụ hữu ích cho nhà phát triển và những người làm việc trong lĩnh vực IT. Nếu bạn thấy nó hữu ích, xin đừng ngần ngại chia sẻ cho những người mà bạn nghĩ sẽ thấy nó hữu ích và đừng quên đánh dấu nó trong thanh lối tắt của bạn!
+
+    IT Tools là mã nguồn mở (dưới giấy phép MIT) và miễn phí, và sẽ luôn như vậy, nhưng tôi phải trả tiền để lưu trữ và gia hạn tên miền. Nếu bạn muốn hỗ trợ công việc của tôi, và khích lệ tôi thêm nhiều công cụ hơn, hãy xem xét hỗ trợ bằng cách [tài trợ cho tôi](https://www.buymeacoffee.com/cthmsst).
+
+    ## Công nghệ
+
+    IT Tools được tạo ra bằng Vue.js (Vue 3) với thư viện thành phần Naive UI và được lưu trữ và triển khai liên tục bởi Vercel. Các thư viện mã nguồn mở của bên thứ ba được sử dụng trong một số công cụ, bạn có thể tìm danh sách đầy đủ trong file [package.json](https://github.com/CorentinTh/it-tools/blob/main/package.json) của kho lưu trữ.
+
+    ## Phát hiện lỗi? Một công cụ bị thiếu?
+
+    Nếu bạn cần một công cụ hiện không có ở đây, và bạn nghĩ rằng nó có thể hữu ích, bạn được chào đón để gửi một yêu cầu tính năng trong [phần vấn đề](https://github.com/CorentinTh/it-tools/issues/new/choose) trong kho GitHub.
+
+    Và nếu bạn phát hiện ra một lỗi, hoặc điều gì đó không hoạt động như mong đợi, xin vui lòng gửi báo cáo lỗi trong [phần vấn đề](https://github.com/CorentinTh/it-tools/issues/new/choose) trong kho GitHub.
+
+404:
+  notFound: '404 Không Tìm Thấy'
+  sorry: 'Xin lỗi, trang này dường như không tồn tại'
+  maybe: 'Có thể bộ nhớ đệm đang làm những điều kỳ lạ, thử làm mới cưỡng bức?'
+  backHome: 'Quay về trang chủ'
+favoriteButton:
+  remove: 'Xóa khỏi mục yêu thích'
+  add: 'Thêm vào mục yêu thích'
+toolCard:
+  new: Mới
+search:
+  label: Tìm kiếm
+tools:
+  categories:
+    favorite-tools: 'Công cụ yêu thích của bạn'
+    crypto: Crypto
+    converter: Chuyển đổi
+    web: Web
+    images and videos: 'Hình ảnh & Video'
+    development: Phát triển
+    network: Mạng
+    math: Toán học
+    measurement: Đo lường
+    text: Văn bản
+    data: Dữ liệu

--- a/src/modules/i18n/components/locale-selector.vue
+++ b/src/modules/i18n/components/locale-selector.vue
@@ -9,6 +9,7 @@ const localesLong: Record<string, string> = {
   ru: 'Русский',
   uk: 'Українська',
   zh: '中文',
+  vi: 'Tiếng Việt',
 };
 
 const localeOptions = computed(() =>

--- a/src/tools/text-to-unicode/text-to-unicode.vue
+++ b/src/tools/text-to-unicode/text-to-unicode.vue
@@ -13,11 +13,11 @@ const { copy: copyText } = useCopy({ source: textFromUnicode });
 
 <template>
   <c-card title="Text to Unicode">
-    <c-input-text v-model:value="inputText" multiline placeholder="e.g. 'Hello Avengers'" label="Enter text to convert to binary" autosize autofocus raw-text test-id="text-to-unicode-input" />
+    <c-input-text v-model:value="inputText" multiline placeholder="e.g. 'Hello Avengers'" label="Enter text to convert to unicode" autosize autofocus raw-text test-id="text-to-unicode-input" />
     <c-input-text v-model:value="unicodeFromText" label="Unicode from your text" multiline raw-text readonly mt-2 placeholder="The unicode representation of your text will be here" test-id="text-to-unicode-output" />
     <div mt-2 flex justify-center>
       <c-button :disabled="!unicodeFromText" @click="copyUnicode()">
-        Copy binary to clipboard
+        Copy unicode to clipboard
       </c-button>
     </div>
   </c-card>


### PR DESCRIPTION
## Related Issue: #850 

## Changes
- Added `Vietnamese Language Support`: Implemented internationalization (i18n) for the Vietnamese language.
- Chore `Text-to-Unicode Conversion Tool Typo Fix`: Corrected a typo in the tool's interface that affected the tool's instructional text. This fix improves clarity and ensures that the tool's functionality is accurately communicated to the users.