### PR TITLE
chore: remove Vue.vscode-typescript-vue-plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin", "dbaeumer.vscode-eslint", "lokalise.i18n-ally"]
+  "recommendations": ["Vue.volar", "dbaeumer.vscode-eslint", "lokalise.i18n-ally"]
 }


### PR DESCRIPTION
because this extension is deprecated
![image](https://github.com/CorentinTh/it-tools/assets/24789441/cfcf802d-0532-4584-9d68-c995fe76d211)
