### PR TITLE
fix(uuid-generator): prevent textarea height increase on refresh

### DIFF
--- a/src/tools/uuid-generator/uuid-generator.vue
+++ b/src/tools/uuid-generator/uuid-generator.vue
@@ -96,14 +96,14 @@ const { copy } = useCopy({ source: uuids, text: 'UUIDs copied to the clipboard' 
       :value="uuids"
       multiline
       placeholder="Your uuids"
-      autosize
-      rows="1"
+      :rows="count"
       readonly
       raw-text
       monospace
       my-3
       class="uuid-display"
     />
+
 
     <div flex justify-center gap-3>
       <c-button autofocus @click="copy()">


### PR DESCRIPTION
The height of the textarea in the UUID Generator component was increasing with each refresh. This commit fixes the issue by using the quantity of UUIDs generated as the row property of the textarea and also removes the autosize property of the textarea.