### PR TITLE
feat: add paste file feature for base64 file converter

### DIFF
--- a/src/tools/base64-file-converter/base64-file-converter.vue
+++ b/src/tools/base64-file-converter/base64-file-converter.vue
@@ -76,6 +76,18 @@ async function onUpload(file: File) {
     fileInput.value = file;
   }
 }
+
+function onPaste(event: ClipboardEvent) {
+  if (event.clipboardData) {
+    const { items } = event.clipboardData;
+    for (const item of items) {
+      const file = item.getAsFile();
+      if (item.kind === 'file' && file) {
+        fileInput.value = file;
+      }
+    }
+  }
+}
 </script>
 
 <template>
@@ -121,8 +133,8 @@ async function onUpload(file: File) {
     </div>
   </c-card>
 
-  <c-card title="File to base64">
-    <c-file-upload title="Drag and drop a file here, or click to select a file" @file-upload="onUpload" />
+  <c-card title="File to base64" @paste="onPaste">
+    <c-file-upload title="Drag and drop a file here, Focus this card and paste a file here, or click to select a file" @file-upload="onUpload" />
     <c-input-text :value="fileBase64" multiline readonly placeholder="File in base64 will be here" rows="5" my-2 />
 
     <div flex justify-center>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "**/*.d.ts", "node_modules/vite-plugin-pwa/client.d.ts"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM.Iterable"],
     "target": "es2022",
     "module": "es2022",
     "moduleResolution": "Node",


### PR DESCRIPTION
I find it would be convenient and quickly if the base64 file converter supports pasting files like images or other types of files. So I tried to add this simple feature.


https://github.com/CorentinTh/it-tools/assets/2276718/8c692d34-d2af-4798-ad78-a153783eb063

