### PR TITLE
feat(text-diff) fix module not loading

### DIFF
--- a/src/tools/text-diff/text-diff.vue
+++ b/src/tools/text-diff/text-diff.vue
@@ -1,5 +1,9 @@
+<script setup lang="ts">
+import CDiffEditor from '@/ui/c-diff-editor/c-diff-editor.vue';
+</script>
+
 <template>
-  <c-card w-full important:flex-1 important:pa-0>
-    <c-diff-editor />
+  <c-card w-full important:flex-1 important:pa-1>
+    <CDiffEditor />
   </c-card>
 </template>


### PR DESCRIPTION
Fix: https://github.com/CorentinTh/it-tools/issues/1291
- looks like the error was happening from dynamically importing the module
- ![image](https://github.com/user-attachments/assets/15fe409d-af8b-4dfb-9c0b-d9190e97575e)
- imported component directly into text-diff.vue file
