### PR TITLE
fix(readme) allow auto refresh of stale contributors graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It will create a directory in `src/tools` with the correct files, and a the impo
 
 Big thanks to all the people who have already contributed!
 
-[![contributors](https://contrib.rocks/image?repo=corentinth/it-tools)](https://github.com/corentinth/it-tools/graphs/contributors)
+[![contributors](https://contrib.rocks/image?repo=corentinth/it-tools&refresh=1)](https://github.com/corentinth/it-tools/graphs/contributors)
 
 ## Credits
 


### PR DESCRIPTION
@CorentinTh 
Allow auto refresh of stale contributors graph onload of main repository page
(if you'd like to have that happen that is)

> **Before:**

![image](https://github.com/user-attachments/assets/b32bc059-a8da-4d87-bed0-d26cec98489a)

> **After:**

![image](https://github.com/user-attachments/assets/6312a50b-99a5-4b9d-9765-ce0f5d4e1b3e)
