### PR TITLE
fix(FavoriteButton) fix favorite button funtionality on tool page

### DIFF
--- a/src/layouts/tool.layout.vue
+++ b/src/layouts/tool.layout.vue
@@ -40,7 +40,7 @@ const toolDescription = computed<string>(() => t(`tools.${i18nKey.value}.descrip
           </n-h1>
 
           <div>
-            <FavoriteButton :tool="{ name: route.meta.name } as Tool" />
+            <FavoriteButton :tool="{ name: route.meta.name, path: route.path } as Tool" />
           </div>
         </div>
 

--- a/src/tools/tools.store.ts
+++ b/src/tools/tools.store.ts
@@ -45,7 +45,10 @@ export const useToolStore = defineStore('tools', () => {
     newTools: computed(() => tools.value.filter(({ isNew }) => isNew)),
 
     addToolToFavorites({ tool }: { tool: MaybeRef<Tool> }) {
-      favoriteToolsName.value.push(get(tool).path);
+      const toolPath = get(tool).path;
+      if (toolPath) {
+        favoriteToolsName.value.push(toolPath);
+      }
     },
 
     removeToolFromFavorites({ tool }: { tool: MaybeRef<Tool> }) {


### PR DESCRIPTION
@CorentinTh
Bug Fix: https://github.com/CorentinTh/it-tools/issues/1365
**- previously was not passing the route path to the object when passing as tool:**
![toollayoutonlypassesname](https://github.com/user-attachments/assets/28f58762-c872-4cef-bd3f-dd3bd66a01cf)
![frompageonlypassesname](https://github.com/user-attachments/assets/fac6d254-4abf-4b18-9fc2-f8cc8ed450d6)

**- this also caused it to add nulls to the favoritesToolName in local storage:**
![addsnull](https://github.com/user-attachments/assets/2c44e408-fa7d-448b-8b59-61a76b6742aa)

**- adding the path should prevent nulls from getting add now but also added if check before adding directly to the store:**
![after change](https://github.com/user-attachments/assets/e57d66a3-ce32-43ec-b473-d789b3e7f44b)

