### PR TITLE
feat(device-information) Time zone information

### DIFF
--- a/src/tools/device-information/device-information.vue
+++ b/src/tools/device-information/device-information.vue
@@ -54,6 +54,19 @@ const sections = [
       },
     ],
   },
+  {
+    name: 'Time zone',
+    information: [
+      {
+        label: 'Time zone name',
+        value: computed(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+      },
+      {
+        label: 'UTC offset',
+        value: computed(() => `${new Date().getTimezoneOffset()} minutes`),
+      },
+    ],
+  },
 ];
 </script>
 


### PR DESCRIPTION
New section of the Device information tool that displays the current time zone name and the offset with UTC in minutes.

![image](https://github.com/user-attachments/assets/8ef788d5-f55c-4ecb-b98d-5820b175c453)
