### PR TITLE
feat(uuid-generator): add support for UUID v7 and update uuid package to version 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ulid": "^2.3.0",
     "unicode-emoji-json": "^0.4.0",
     "unplugin-auto-import": "^0.16.4",
-    "uuid": "^9.0.0",
+    "uuid": "^11.0.0",
     "vue": "^3.3.4",
     "vue-i18n": "^9.9.1",
     "vue-router": "^4.1.6",

--- a/src/tools/uuid-generator/uuid-generator.vue
+++ b/src/tools/uuid-generator/uuid-generator.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { v1 as generateUuidV1, v3 as generateUuidV3, v4 as generateUuidV4, v5 as generateUuidV5, NIL as nilUuid } from 'uuid';
+import { v1 as generateUuidV1, v3 as generateUuidV3, v4 as generateUuidV4, v5 as generateUuidV5, v7 as generateUuidV7, NIL as nilUuid } from 'uuid';
 import { useCopy } from '@/composable/copy';
 import { computedRefreshable } from '@/composable/computedRefreshable';
 import { withDefaultOnError } from '@/utils/defaults';
 
-const versions = ['NIL', 'v1', 'v3', 'v4', 'v5'] as const;
+const versions = ['NIL', 'v1', 'v3', 'v4', 'v5', 'v7'] as const;
 
 const version = useStorage<typeof versions[number]>('uuid-generator:version', 'v4');
 const count = useStorage('uuid-generator:quantity', 1);
@@ -34,6 +34,7 @@ const generators = {
   v3: () => generateUuidV3(v35Args.value.name, v35Args.value.namespace),
   v4: () => generateUuidV4(),
   v5: () => generateUuidV5(v35Args.value.name, v35Args.value.namespace),
+  v7: () => generateUuidV7(),
 };
 
 const [uuids, refreshUUIDs] = computedRefreshable(() => withDefaultOnError(() =>


### PR DESCRIPTION
This pull request includes updates to the `uuid` package version and the addition of UUID version 7 support in the UUID generator component.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L96-R96): Updated the `uuid` package from version `^9.0.0` to `^11.0.0`.

UUID generator enhancements:

* [`src/tools/uuid-generator/uuid-generator.vue`](diffhunk://#diff-beb5e889bfafbdfa945376ca7dabe19d16e0a2d66348e2d9d1f7e1eb424d53bdL2-R7): Imported the `v7` method from the `uuid` package and added it to the list of supported UUID versions.
* [`src/tools/uuid-generator/uuid-generator.vue`](diffhunk://#diff-beb5e889bfafbdfa945376ca7dabe19d16e0a2d66348e2d9d1f7e1eb424d53bdR37): Added the `v7` generator to the `generators` object to support UUID version 7 generation.
* 
https://github.com/user-attachments/assets/f72d3932-bb1a-438c-bb2a-8030e1fb6a8d

