### PR TITLE
fix(yaml-viewer): prevent large integers from being converted to expo…

### DIFF
--- a/src/tools/yaml-viewer/yaml-models.ts
+++ b/src/tools/yaml-viewer/yaml-models.ts
@@ -13,7 +13,7 @@ function formatYaml({
   sortKeys?: MaybeRef<boolean>
   indentSize?: MaybeRef<number>
 }) {
-  const parsedYaml = yaml.parse(get(rawYaml));
+  const parsedYaml = yaml.parse(get(rawYaml), { intAsBigInt: true });
 
   const formattedYAML = yaml.stringify(parsedYaml, {
     sortMapEntries: get(sortKeys),


### PR DESCRIPTION
fix #1398

Currently, the YAML viewer (YAML prettify and format) converts large integers to exponential notation. To prevent this, I enabled the `intAsBigInt` configuration, which is an option provided by the YAML library. For more details, you can refer to the [yaml parse options](https://eemeli.org/yaml/#parse-options)