### PR TITLE
Add ipv6 support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
Added ipv6 listen statement to NGINX config, to support running this project inside an ipv6 only enviorment (k8s cluster in my case)

I have verified that it does not cause any problems on ipv4 only networks, this change simply adds another listener to nginx, without modifiing the current one.

netstat without this change
/ # netstat -ltnp
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      1/nginx: master pro

Netstat with this change
/ # netstat -ltnp
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 :::80                   :::*                    LISTEN      1/nginx: master pro
