### PR TITLE
Fix the bug related to the text input been to small when the icon is not present in the input

### DIFF
--- a/src/ui/c-input-text/c-input-text.vue
+++ b/src/ui/c-input-text/c-input-text.vue
@@ -259,6 +259,7 @@ defineExpose({
     border-radius: 4px;
     padding: 0 4px 0 12px;
     transition: border-color 0.2s ease-in-out;
+    min-height:30px;
 
     .multiline& {
       resize: vertical;


### PR DESCRIPTION
:lady_beetle:  The text input are to small when a icon is not present 

![Screenshot 2025-02-21 at 14-00-02 Basic auth generator - IT Tools](https://github.com/user-attachments/assets/52003957-805a-4527-a1b2-37aa3e3c390f)
![Screenshot 2025-02-21 at 14-02-29 Open graph meta generator - IT Tools](https://github.com/user-attachments/assets/481a8696-786a-4af6-9f90-474b9b84f454)

Fix: add a min h to the input wrapper base on the smallest input that is 30px

