### PR TITLE
fix(input-text): increase vertical padding for improved layout

### DIFF
--- a/src/ui/c-input-text/c-input-text.vue
+++ b/src/ui/c-input-text/c-input-text.vue
@@ -286,7 +286,7 @@ defineExpose({
       flex: 1 1 0;
       min-width: 0;
 
-      padding: 8px 0;
+      padding: 16px 0;
       outline: none;
       background-color: transparent;
       background-image: none;


### PR DESCRIPTION
### I see that some of the text input is not proportional, example is right here

#### crontab-generator
<img width="618" alt="image" src="https://github.com/user-attachments/assets/0482d70e-8b96-4f63-808c-c53a55d76f18" />

#### base-converter
<img width="619" alt="image" src="https://github.com/user-attachments/assets/9d610086-29da-43f7-b295-e27c66fea725" />

<br />
<br />

### this update is changing the padding from `8px` to `16px`, the result is like this:

#### crontab-generator
<img width="590" alt="image" src="https://github.com/user-attachments/assets/7e94b5bf-420c-4aad-bc25-19f6b6b8d71f" />

#### base-converter
<img width="618" alt="image" src="https://github.com/user-attachments/assets/c3df796c-3e0b-43c1-a1b9-a53f140c016c" />