### PR TITLE
ci: 添加 Halo 部署工作流

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,26 @@
+name: Deploy to Halo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm build
+      - name: Deploy to Halo
+        run: |
+          npx halo-static-pages-deploy-cli deploy -e ${{ secrets.ENDPOINT }} -i ${{ secrets.ID }} -t ${{ secrets.PAT }} -f dist


### PR DESCRIPTION
- 新增 GitHub Actions 工作流，用于将项目部署到 Halo
- 工作流在 Ubuntu 最新版本上运行，包含以下步骤： -检出代码
  - 设置 pnpm
  - 设置 Node.js 环境 -安装依赖
  - 构建项目
  - 使用 Halo静态页面部署 CLI 工具进行部署
- 部署所需的 Halo 相关密钥（ENDPOINT、ID、PAT）需在 GitHub 仓库设置中配置