### PR TITLE
Make it possible to override nginx listen port in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN pnpm build
 # production stage
 FROM nginx:stable-alpine AS production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+
+ENV PORT=80
+EXPOSE $PORT
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${PORT};
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
It's sometimes useful to have the app listen on a different port, e.g. reverse proxy by convention with wildcard CNAME setup.

Fixes #1450 (already closed but with unsatisfactory result IMHO)
