### PR TITLE
Slash removed from ASCII Art font URL

### DIFF
--- a/src/tools/ascii-text-drawer/ascii-text-drawer.vue
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.vue
@@ -9,7 +9,7 @@ const output = ref('');
 const errored = ref(false);
 const processing = ref(false);
 
-figlet.defaults({ fontPath: '//unpkg.com/figlet@1.6.0/fonts/' });
+figlet.defaults({ fontPath: '//unpkg.com/figlet@1.6.0/fonts' });
 
 watchEffect(async () => {
   processing.value = true;


### PR DESCRIPTION
The slash at the end of the address causes the URL for reloading the fonts to have an additional slash. This causes the reloading to abort with a 404 error and the ASCII art cannot be generated.