### PR TITLE
fix(i18n): remove duplicate 'the' in About page

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,7 +37,7 @@ about:
 
     ## Technologies
 
-    IT Tools is made in Vue.js (Vue 3) with the the Naive UI component library and is hosted and continuously deployed by Vercel. Third-party open-source libraries are used in some tools, you may find the complete list in the [package.json](https://github.com/CorentinTh/it-tools/blob/main/package.json) file of the repository.
+    IT Tools is made in Vue.js (Vue 3) with the Naive UI component library and is hosted and continuously deployed by Vercel. Third-party open-source libraries are used in some tools, you may find the complete list in the [package.json](https://github.com/CorentinTh/it-tools/blob/main/package.json) file of the repository.
 
     ## Found a bug? A tool is missing?
 


### PR DESCRIPTION
## Summary
Fixes #1730

## What changed
Removed the duplicate word 'the' in the About page content.

**Before:** "IT Tools is made in Vue.js (Vue 3) with **the the** Naive UI component library..."

**After:** "IT Tools is made in Vue.js (Vue 3) with **the** Naive UI component library..."

## Location
- File: `locales/en.yml`
- Section: `about.content` → Technologies paragraph