### PR TITLE
Fix fontPath URL in figlet defaults

### DIFF
--- a/src/tools/ascii-text-drawer/ascii-text-drawer.vue
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.vue
@@ -9,7 +9,7 @@ const output = ref('');
 const errored = ref(false);
 const processing = ref(false);
 
-figlet.defaults({ fontPath: '//unpkg.com/figlet@1.6.0/fonts/' });
+figlet.defaults({ fontPath: '//unpkg.com/figlet@1.6.0/fonts' });
 
 watchEffect(async () => {
   processing.value = true;


### PR DESCRIPTION
Fix this issue

<img width="517" height="75" alt="image" src="https://github.com/user-attachments/assets/8ba1fe7e-1334-4a32-b863-139a0bfb033c" />