### PR TITLE
docs(readme): drop stray 'a' in Create-a-new-tool section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To create a new tool, there is a script that generate the boilerplate of the new
 pnpm run script:create:tool my-tool-name
 ```
 
-It will create a directory in `src/tools` with the correct files, and a the import in `src/tools/index.ts`. You will just need to add the imported tool in the proper category and develop the tool.
+It will create a directory in `src/tools` with the correct files, and the import in `src/tools/index.ts`. You will just need to add the imported tool in the proper category and develop the tool.
 
 ## Contributors
 


### PR DESCRIPTION
Closes #1780. README.md:112 currently reads `'...with the correct files, and a the import in src/tools/index.ts'` — the extra `a` before `the import` is a typo. One-word removal so the sentence scans.