### PR TITLE
fix: upgrade nginx base image to fix CVE-2026-42945 (CVSS 9.2 critical RCE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN pnpm build
 
 # production stage
-FROM nginx:stable-alpine AS production-stage
+FROM nginx:1.31-alpine AS production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## What

Switches the production stage base image from `nginx:stable-alpine` to `nginx:1.31-alpine`.

## Why

**CVE-2026-42945** — Heap-based Buffer Overflow in `ngx_http_rewrite_module`

- **CVSS v4:** 9.2 (Critical)
- **Impact:** Unauthenticated remote attacker can crash nginx worker processes or achieve **Remote Code Execution** on systems with ASLR disabled
- **Affected:** nginx 0.6.27 – 1.30.0 (current `nginx:stable-alpine` ships 1.26.x)
- **Fixed in:** nginx 1.30.1 / **1.31.0**
- **PoC:** Publicly available since 2026-05-13
- **Advisory:** https://nginx.org/en/security_advisories.html (F5 K000161019)

## Change

```diff
-FROM nginx:stable-alpine AS production-stage
+FROM nginx:1.31-alpine AS production-stage
```

`nginx:stable-alpine` currently resolves to nginx 1.26.x which is vulnerable. Pinning to `1.31-alpine` ensures the patched version is used. This can be reverted to `nginx:stable-alpine` once the stable branch is updated upstream by the nginx team.