### PR TITLE
Fix(Update figlet font path to version 1.10.0)

### DIFF
--- a/src/tools/ascii-text-drawer/ascii-text-drawer.vue
+++ b/src/tools/ascii-text-drawer/ascii-text-drawer.vue
@@ -9,7 +9,7 @@ const output = ref('');
 const errored = ref(false);
 const processing = ref(false);
 
-figlet.defaults({ fontPath: '//unpkg.com/figlet@1.6.0/fonts/' });
+figlet.defaults({ fontPath: '//unpkg.com/figlet@1.10.0/fonts/' });
 
 watchEffect(async () => {
   processing.value = true;


### PR DESCRIPTION
I updated the Figlet font path to version 1.10.0 because ascii-text-drawer no longer works.

With the old version 1.6.0, the Figlet Standard font URL https://unpkg.com/figlet@1.6.0/fonts//Standard.flf
returned a 404 error.