### PR TITLE
Add repocloud deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corent
 - [Tipi](https://www.runtipi.io/docs/apps-available)
 - [Unraid](https://unraid.net/community/apps?q=it-tools)
 
+**One-click deploy:**
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/IT%20Tools/)
+
 ## Contribute
 
 ### Recommended IDE Setup

--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ docker run -d --name it-tools --restart unless-stopped -p 8080:80 ghcr.io/corent
 - [Cloudron](https://www.cloudron.io/store/tech.ittools.cloudron.html)
 - [Tipi](https://www.runtipi.io/docs/apps-available)
 - [Unraid](https://unraid.net/community/apps?q=it-tools)
-
-**One-click deploy:**
-
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/IT%20Tools/)
+- [RepoCloud](https://repocloud.io/details/IT%20Tools/)
 
 ## Contribute
 


### PR DESCRIPTION
This PR adds [RepoCloud](https://repocloud.io/details/IT%20Tools/) as a self-hosting option in the "Other solutions" section of the README.

RepoCloud provides one-click cloud deployment for open-source applications, making it easy for users to self-host IT Tools without manual Docker configuration.